### PR TITLE
Remove false positive FS003 for pure regex-strings containing curly brackets

### DIFF
--- a/flake8_use_fstring/prefix.py
+++ b/flake8_use_fstring/prefix.py
@@ -11,7 +11,7 @@ from .base import (
 
 FSTRING_REGEX = _re.compile(r'^([a-zA-Z]*?[fF][a-zA-Z]*?){1}["\']')
 NON_FSTRING_REGEX = _re.compile(
-    r'^[a-zA-Z]*(?:\'\'\'|\'|"""|")(.*?{.+?}.*)(?:\'|\'\'\'|"|""")$',
+    r'^[a-zA-Z]*(?<!\b[rR])(?:\'\'\'|\'|"""|")(.*?{.+?}.*)(?:\'|\'\'\'|"|""")$',
 )
 
 


### PR DESCRIPTION
ref #6, #7  
Fixes false positives on pure regex strings prefixed with only a single `r`, containing curly brackets as repetition quantifiers, by utilizing a negative lookbehind. 