### PR TITLE
build: support flake8 v4.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     python_requires='>=3.6',
 
     install_requires=[
-        'flake8==3.*',
+        'flake8 >=3',
     ],
 
     extras_require={


### PR DESCRIPTION
Closes #10 

Tests succeed locally with `flake8` v4.x. Check the Travis log to see whether it installs v4.x as well.