### PR TITLE
fix: show package version for plugins

### DIFF
--- a/flake8_use_fstring/format.py
+++ b/flake8_use_fstring/format.py
@@ -3,11 +3,12 @@ import token as _token
 from .base import (
     BaseGreedyLogicalLineChecker as _Base,
 )
+from . import __version__
 
 
 class StrFormatDetector(_Base):
     name = 'use-fstring-format'
-    version = '1.0'
+    version = __version__
 
     def __getitem__(self, i: int) -> bool:
         token = self.tokens[i]

--- a/flake8_use_fstring/percent.py
+++ b/flake8_use_fstring/percent.py
@@ -3,11 +3,12 @@ import token as _token
 from .base import (
     BaseGreedyLogicalLineChecker as _Base,
 )
+from . import __version__
 
 
 class PercentFormatDetector(_Base):
     name = 'use-fstring-percent'
-    version = '1.0'
+    version = __version__
 
     def __getitem__(self, i: int) -> bool:
         return self.tokens[i].exact_type == _token.PERCENT

--- a/flake8_use_fstring/prefix.py
+++ b/flake8_use_fstring/prefix.py
@@ -9,6 +9,8 @@ from .base import (
     BaseLogicalLineChecker as _Base,
 )
 
+from . import __version__
+
 FSTRING_REGEX = _re.compile(r'^([a-zA-Z]*?[fF][a-zA-Z]*?){1}["\']')
 NON_FSTRING_REGEX = _re.compile(
     r'^[a-zA-Z]*(?:\'\'\'|\'|"""|")(.*?{.+?}.*)(?:\'|\'\'\'|"|""")$',
@@ -17,7 +19,7 @@ NON_FSTRING_REGEX = _re.compile(
 
 class MissingPrefixDetector(_Base):
     name = 'use-fstring-prefix'
-    version = '1.0'
+    version = __version__
     ignore_format = False
     off_by_default = True
 


### PR DESCRIPTION
Adjust the `__version__` imports so all the plugins show the same version as the package. May be helpful for debugging.

Previous 

```console
$ flake8 --version
4.0.1 (mccabe: 0.6.1, pycodestyle: 2.8.0, pyflakes: 2.4.0, use-fstring-format: 1.0, use-fstring-percent: 1.0, use-
fstring-prefix: 1.0) CPython 3.9.7 on Windows
```

After

```console
$ flake8 --version
4.0.1 (flake8-fixme: 1.1.1, flake8-print: 4.0.0, flake8-todo: 0.7, flake8_builtins: 1.5.2, flake8_commas: 2.1.0,
flake8_quotes: 3.3.0, mccabe: 0.6.1, pycodestyle: 2.8.0, pyflakes: 2.4.0, use-fstring-format: 1.2, use-fstring-
percent: 1.2, use-fstring-prefix: 1.2) CPython 3.9.7 on Windows
```